### PR TITLE
Add AWS module for users management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Local .terraform directories
+**/.terraform*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# IDEA
+.idea
+*.iml
+
+# Vscode
+.vscode
+
+# Emacs
+.dir-locals.el
+
+# Trivy
+trivy-output.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.8.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-terraform 1.8.2

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,43 @@
+module "iam_groups" {
+  source = "./modules/iam_groups"
+}
+
+module "iam_admin_users" {
+  source = "./modules/iam_users"
+
+  usernames = var.admins_emails
+}
+
+module "iam_developer_users" {
+  source = "./modules/iam_users"
+
+  usernames = var.developers_emails
+}
+
+module "iam_infra_service_account_users" {
+  source = "./modules/iam_users"
+
+  usernames = var.infra_service_accounts_emails
+  has_login = false
+}
+
+module "iam_group_membership" {
+  source = "./modules/iam_group_membership"
+
+  for_each = {
+    admin                 = { group = module.iam_groups.admin_group, users = var.admins_emails },
+    infra_service_account = { group = module.iam_groups.infra_service_account_group, users = var.infra_service_accounts_emails },
+    developer             = { group = module.iam_groups.developer_group, users = var.developers_emails }
+  }
+
+  name  = "${each.key}-group-membership"
+  group = each.value.group
+  users = each.value.users
+
+  depends_on = [
+    module.iam_groups,
+    module.iam_admin_users,
+    module.iam_developer_users,
+    module.iam_infra_service_account_users,
+  ]
+}

--- a/modules/iam_group_membership/main.tf
+++ b/modules/iam_group_membership/main.tf
@@ -1,0 +1,6 @@
+resource "aws_iam_group_membership" "group" {
+  name = var.name
+
+  group = var.group
+  users = var.users
+}

--- a/modules/iam_group_membership/variables.tf
+++ b/modules/iam_group_membership/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "The name to identify the Group Membership"
+  type        = string
+}
+
+variable "group" {
+  description = "The IAM Group name to attach the list of users to"
+  type        = string
+}
+
+variable "users" {
+  description = "A list of IAM User names to associate with the Group"
+  type        = list(string)
+}

--- a/modules/iam_groups/data.tf
+++ b/modules/iam_groups/data.tf
@@ -1,0 +1,144 @@
+locals {
+  # Comes from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
+  # This policy allows users to view and edit their own passwords, access keys, MFA devices, X.509 certificates, SSH keys, and Git credentials. 
+  # In addition, users are required to set up and authenticate using MFA before performing any other operations in AWS. 
+  # It also means this policy does NOT allow users to reset a password while signing in to the AWS Management Console for the first time. 
+  # They must first set up their MFA because allowing users to change their password without MFA can be a security risk.
+  # 
+  # The following actions are added to the initial policy from AWS
+  # - iam:GetLoginProfile: allows the IAM user to view their account information on the security page.
+  # - iam:GetAccessKeyLastUsed: allows the IAM user to view the last time their access key was used.
+  allow_manage_own_credentials = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowViewAccountInfo"
+        Effect = "Allow"
+        Action = [
+          "iam:GetAccountPasswordPolicy",
+          "iam:ListVirtualMFADevices",
+          "iam:GetLoginProfile"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowManageOwnPasswords"
+        Effect = "Allow"
+        Action = [
+          "iam:ChangePassword",
+          "iam:GetUser"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnAccessKeys"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccessKey",
+          "iam:DeleteAccessKey",
+          "iam:ListAccessKeys",
+          "iam:GetAccessKeyLastUsed",
+          "iam:UpdateAccessKey"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnSigningCertificates"
+        Effect = "Allow"
+        Action = [
+          "iam:DeleteSigningCertificate",
+          "iam:ListSigningCertificates",
+          "iam:UpdateSigningCertificate",
+          "iam:UploadSigningCertificate"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnSSHPublicKeys"
+        Effect = "Allow"
+        Action = [
+          "iam:DeleteSSHPublicKey",
+          "iam:GetSSHPublicKey",
+          "iam:ListSSHPublicKeys",
+          "iam:UpdateSSHPublicKey",
+          "iam:UploadSSHPublicKey"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnGitCredentials"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateServiceSpecificCredential",
+          "iam:DeleteServiceSpecificCredential",
+          "iam:ListServiceSpecificCredentials",
+          "iam:ResetServiceSpecificCredential",
+          "iam:UpdateServiceSpecificCredential"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnVirtualMFADevice"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateVirtualMFADevice"
+        ]
+        Resource = "arn:aws:iam::*:mfa/*"
+      },
+      {
+        Sid    = "AllowManageOwnUserMFA"
+        Effect = "Allow"
+        Action = [
+          "iam:DeactivateMFADevice",
+          "iam:EnableMFADevice",
+          "iam:ListMFADevices",
+          "iam:ResyncMFADevice"
+        ]
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "DenyAllExceptListedIfNoMFA"
+        Effect = "Deny"
+        NotAction = [
+          "iam:CreateVirtualMFADevice",
+          "iam:ChangePassword",
+          "iam:EnableMFADevice",
+          "iam:GetAccountPasswordPolicy",
+          "iam:GetUser",
+          "iam:ListMFADevices",
+          "iam:ListVirtualMFADevices",
+          "iam:ResyncMFADevice",
+          "sts:GetSessionToken"
+        ]
+        Resource = "*"
+        Condition = {
+          BoolIfExists = {
+            "aws:MultiFactorAuthPresent" = "false"
+          }
+        }
+      }
+    ]
+  })
+
+  # For the infra service account
+  # It must be able to manage policies during terraform apply & create/delete users, permissions, etc. during terraform apply
+  full_iam_access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowManageRoleAndPolicy"
+        Effect   = "Allow"
+        Resource = ["arn:aws:iam::*"]
+        Action   = ["iam:*"]
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy" "admin_access" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+data "aws_iam_policy" "power_user_access" {
+  arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}

--- a/modules/iam_groups/main.tf
+++ b/modules/iam_groups/main.tf
@@ -1,0 +1,37 @@
+resource "aws_iam_group" "admin" {
+  name = "Admins-group"
+}
+
+resource "aws_iam_group" "developer" {
+  name = "Developers-group"
+}
+
+resource "aws_iam_group" "infra-service-account" {
+  name = "Infra-service-accounts-group"
+}
+
+resource "aws_iam_group_policy_attachment" "admin_access" {
+  group      = aws_iam_group.admin.name
+  policy_arn = data.aws_iam_policy.admin_access.arn
+}
+
+resource "aws_iam_group_policy" "developer_allow_manage_own_credentials" {
+  group  = aws_iam_group.developer.name
+  policy = local.allow_manage_own_credentials
+}
+
+resource "aws_iam_group_policy_attachment" "developer_power_user_access" {
+  group      = aws_iam_group.developer.name
+  policy_arn = data.aws_iam_policy.power_user_access.arn
+}
+
+resource "aws_iam_group_policy_attachment" "infra_service_account_power_user_access" {
+  group      = aws_iam_group.infra-service-account.name
+  policy_arn = data.aws_iam_policy.power_user_access.arn
+}
+
+resource "aws_iam_group_policy" "infra_service_account_full_iam_access" {
+  name   = "AllowFullIamAccess"
+  group  = aws_iam_group.infra-service-account.name
+  policy = local.full_iam_access_policy
+}

--- a/modules/iam_groups/outputs.tf
+++ b/modules/iam_groups/outputs.tf
@@ -1,0 +1,14 @@
+output "admin_group" {
+  description = "IAM Group with admin permissions"
+  value       = aws_iam_group.admin.name
+}
+
+output "developer_group" {
+  description = "IAM Group with developer permissions"
+  value       = aws_iam_group.developer.name
+}
+
+output "infra_service_account_group" {
+  description = "IAM Group with Infra Service Account permissions"
+  value       = aws_iam_group.infra-service-account.name
+}

--- a/modules/iam_users/main.tf
+++ b/modules/iam_users/main.tf
@@ -1,0 +1,33 @@
+locals {
+  user_accounts = var.has_login ? aws_iam_user.user_account : {}
+}
+
+resource "aws_iam_user" "user_account" {
+  for_each = toset(var.usernames)
+
+  name = each.value
+  path = var.path
+
+  force_destroy = true
+
+  # If an access key is generated, the account will be tagged automatically with the Key ID 
+  # and each TF run will try to remove the tag.
+  lifecycle {
+    ignore_changes = [
+      tags,
+      tags_all
+    ]
+  }
+}
+
+resource "aws_iam_user_login_profile" "user_account" {
+  for_each = local.user_accounts
+
+  user = each.value.name
+
+  lifecycle {
+    ignore_changes = [
+      password_reset_required,
+    ]
+  }
+}

--- a/modules/iam_users/outputs.tf
+++ b/modules/iam_users/outputs.tf
@@ -1,0 +1,3 @@
+output "temporary_passwords" {
+  value = { for username, login_profile in aws_iam_user_login_profile.user_account : username => login_profile.password }
+}

--- a/modules/iam_users/outputs.tf
+++ b/modules/iam_users/outputs.tf
@@ -1,3 +1,0 @@
-output "temporary_passwords" {
-  value = { for username, login_profile in aws_iam_user_login_profile.user_account : username => login_profile.password }
-}

--- a/modules/iam_users/variables.tf
+++ b/modules/iam_users/variables.tf
@@ -1,0 +1,14 @@
+variable "usernames" {
+  description = "Desired names for the IAM user"
+  type        = list(string)
+}
+
+variable "path" {
+  description = "Desired path for the IAM user"
+  default     = "/"
+}
+
+variable "has_login" {
+  description = "Boolean for whether login is enabled"
+  default     = true
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.47.0"
+    }
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.47.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,6 @@ variable "developers_emails" {
 }
 
 variable "infra_service_accounts_emails" {
-  type        = string
+  type        = list(string)
   description = "List of emails of the service accounts"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "admins_emails" {
+  type        = list(string)
+  description = "List of emails of the admins"
+}
+
+variable "developers_emails" {
+  type        = list(string)
+  description = "List of emails of the developers"
+}
+
+variable "infra_service_accounts_emails" {
+  type        = string
+  description = "List of emails of the service accounts"
+}


### PR DESCRIPTION
It allows to create three groups of users:
- Admins
- Developers
- Service account

This module will be used in Opsmaru configuration to create AWS users.